### PR TITLE
feat: match events and execute corresponding order execution

### DIFF
--- a/keeper/Cargo.toml
+++ b/keeper/Cargo.toml
@@ -19,6 +19,7 @@ reqwest = { version = "0.12.4", features = ["json"] }
 dotenv = "0.15.0"
 actix-web = "4.7.0"
 thiserror = "1.0.61"
+url = "2.5.1"
 
 
 [dev-dependencies]

--- a/keeper/src/deposit/handle.rs
+++ b/keeper/src/deposit/handle.rs
@@ -1,4 +1,4 @@
-use std::{env, vec};
+use std::{env, vec, sync::Arc};
 
 use cainome::{
     cairo_serde::{ContractAddress, U256},
@@ -11,15 +11,15 @@ use starknet::{
     signers::LocalWallet,
 };
 
-use crate::types::SatoruAction;
+use crate::{price::utils::get_pragma_price, types::SatoruAction};
 
 abigen!(
     DepositHandler,
     "./resources/satoru_DepositHandler.contract_class.json"
 );
 
-async fn handle_deposit(
-    account: SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+pub async fn handle_deposit(
+    account: Arc<SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>>,
     deposit: SatoruAction,
 ) {
     let deposit_handler_address =

--- a/keeper/src/error.rs
+++ b/keeper/src/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum KeeperError {
+    #[error("Invalid RPC Url")]
+    ProviderUrlError(String),
+    #[error("RPC_URL not set")]
+    RpcUrlNotSet(),
+    #[error("PRIVATE_KEY not set")]
+    PrivateKeyNotSet(),
+    #[error("PUBLIC_KEY not set")]
+    PublicKeyNotSet(),
+}

--- a/keeper/src/lib.rs
+++ b/keeper/src/lib.rs
@@ -4,3 +4,4 @@ pub mod order;
 pub mod price;
 pub mod types;
 pub mod withdrawal;
+pub mod error;

--- a/keeper/src/listen_db.rs
+++ b/keeper/src/listen_db.rs
@@ -6,6 +6,7 @@ use sqlx::error::Error;
 use sqlx::postgres::PgListener;
 use sqlx::Pool;
 use sqlx::Postgres;
+use tokio::task::JoinHandle;
 
 // Listens to notifications from PostgreSQL channels.
 // @pool: A reference to a connection pool for PostgreSQL.
@@ -14,7 +15,7 @@ use sqlx::Postgres;
 pub async fn start_listening<T: DeserializeOwned + Sized + Debug>(
     pool: &Pool<Postgres>,
     channels: Vec<&str>,
-    call_back: impl Fn(T),
+    call_back: impl Fn(T) -> JoinHandle<()>,
 ) -> Result<(), Error> {
     // Initiate the logger.
     env_logger::init();

--- a/keeper/src/main.rs
+++ b/keeper/src/main.rs
@@ -1,33 +1,72 @@
+use std::{env, sync::Arc};
+use dotenv::dotenv;
+
 use keeper_satoru::{
-    listen_db::start_listening,
-    types::{ActionType, Payload},
+    deposit::handle::handle_deposit, error::KeeperError, listen_db::start_listening, order::handle::handle_order, types::{ActionType, Payload}, withdrawal::handle::handle_withdrawal
 };
+use starknet::{accounts::{ExecutionEncoding, SingleOwnerAccount}, core::{chain_id, types::FieldElement}, providers::{jsonrpc::HttpTransport, JsonRpcClient}, signers::{LocalWallet, SigningKey}};
+use tokio::task;
+use url::Url;
 
 #[tokio::main]
 async fn main() {
+    dotenv().ok();
+
     let pool = sqlx::PgPool::connect("postgres://postgres:123@localhost:5432/zohal")
         .await
         .unwrap();
 
-    let channels: Vec<&str> = vec!["orders_update", "deposits_update", "withdrawals_update"];
+    let provider = JsonRpcClient::new(HttpTransport::new(
+        Url::parse(&env::var("RPC_URL").or_else(|e| Err(KeeperError::RpcUrlNotSet())).unwrap())
+            .map_err(|e| KeeperError::ProviderUrlError(format!("invalid rpc url: {}", e))).unwrap(),
+    ));
 
+    let signer = LocalWallet::from(SigningKey::from_secret_scalar(
+        FieldElement::from_hex_be(
+            &env::var("PRIVATE_KEY").or_else(|e| Err(KeeperError::PrivateKeyNotSet())).unwrap()
+        ).expect("Could not convert private key to felt."),
+    ));
+
+
+    let account: SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet> = SingleOwnerAccount::new(
+        provider,
+        signer,
+        FieldElement::from_hex_be(
+            &env::var("PUBLIC_KEY").or_else(|e| Err(KeeperError::PublicKeyNotSet())).unwrap()
+        ).expect("Could not convert private key to felt."),
+        chain_id::TESTNET,
+        ExecutionEncoding::Legacy
+    );
+
+    let account_ref = Arc::new(account);
+    let channels: Vec<&str> = vec!["orders_update", "deposits_update", "withdrawals_update"];
     let call_back = |payload: Payload| {
-        println!("{:?}", payload.row_data);
-        match payload.table.as_str() {
-            "orders" => match payload.action_type {
-                ActionType::INSERT => {}
-                ActionType::UPDATE => {}
-            },
-            "deposits" => match payload.action_type {
-                ActionType::INSERT => {}
-                ActionType::UPDATE => {}
-            },
-            "withdrawals" => match payload.action_type {
-                ActionType::INSERT => {}
-                ActionType::UPDATE => {}
-            },
-            &_ => {}
-        }
+        let account_ref = Arc::clone(&account_ref);
+        task::spawn( async move {
+            println!("{:?}", payload.row_data);
+            let account_ref = Arc::clone(&account_ref);
+            match payload.table.as_str() {
+                "orders" => match payload.action_type {
+                    ActionType::INSERT => {
+                        handle_order(Arc::clone(&account_ref), payload.row_data).await;
+                    }
+                    ActionType::UPDATE => {}
+                },
+                "deposits" => match payload.action_type {
+                    ActionType::INSERT => {
+                        handle_deposit(Arc::clone(&account_ref), payload.row_data).await;
+                    }
+                    ActionType::UPDATE => {}
+                },
+                "withdrawals" => match payload.action_type {
+                    ActionType::INSERT => {
+                        handle_withdrawal(Arc::clone(&account_ref), payload.row_data).await;
+                    }
+                    ActionType::UPDATE => {}
+                },
+                &_ => {}
+            }
+        })
     };
     println!("Keeper connected to DB and listening...");
 

--- a/keeper/src/order/handle.rs
+++ b/keeper/src/order/handle.rs
@@ -1,4 +1,4 @@
-use std::{env, vec};
+use std::{env, vec, sync::Arc};
 
 use cainome::{
     cairo_serde::{ContractAddress, U256},
@@ -11,15 +11,18 @@ use starknet::{
     signers::LocalWallet,
 };
 
-use crate::types::SatoruAction;
+use crate::{
+    types::SatoruAction,
+    price::utils::get_pragma_price
+};
 
 abigen!(
     OrderHandler,
     "./resources/satoru_OrderHandler.contract_class.json"
 );
 
-async fn handle_order(
-    account: SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+pub async fn handle_order(
+    account: Arc<SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>>,
     order: SatoruAction,
 ) {
     let order_handler_address =

--- a/keeper/src/price/utils.rs
+++ b/keeper/src/price/utils.rs
@@ -28,7 +28,7 @@ struct PriceInfo {
     timestamp: u64,
 }
 
-async fn handler(path: PathParams, query: QueryParams) -> Result<PriceInfo, PragmaAPIError> {
+pub async fn get_pragma_price(path: PathParams, query: QueryParams) -> Result<PriceInfo, PragmaAPIError> {
     let api_url = format!(
         "https://api.dev.pragma.build/node/v1/data/{}/{}?interval={}&aggregation={}&timestamp={}",
         path.base, path.quote, path.interval, query.aggregation, path.timestamp
@@ -81,7 +81,7 @@ mod tests {
             aggregation: "median".to_owned(),
         };
 
-        let price_info = handler(path, query).await;
+        let price_info = get_pragma_price(path, query).await;
         match price_info {
             Ok(price_info) => {
                 assert_eq!(price_info.decimals, 8);

--- a/keeper/src/withdrawal/handle.rs
+++ b/keeper/src/withdrawal/handle.rs
@@ -1,4 +1,4 @@
-use std::{env, vec};
+use std::{env, vec, sync::Arc};
 
 use cainome::{
     cairo_serde::{ContractAddress, U256},
@@ -18,8 +18,8 @@ abigen!(
     "./resources/satoru_WithdrawalHandler.contract_class.json"
 );
 
-async fn handle_withdrawal(
-    account: SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+pub async fn handle_withdrawal(
+    account: Arc<SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>>,
     withdrawal: SatoruAction,
 ) {
     let withdrawal_handler_address =


### PR DESCRIPTION
# Pull Request type

- Feature

## What is the current behavior?

Events get matched but corresponding execution is not started (deposit, order, withdrawal)

## What is the new behavior?

Start execution on receiving sql event and handle async threads
